### PR TITLE
Adapt to application setup that specifies that the backend is availab…

### DIFF
--- a/src/app/globals.ts
+++ b/src/app/globals.ts
@@ -17,7 +17,7 @@ export const globals = {
   iriPatternRepoInstance: 'https://purl.org/patternpedia#LinkedOpenPatterns',
   urlGithubAPI: 'https://api.github.com/repos/PatternPedia/patternpediacontent/contents',
   loadOntologyLocally: true,
-  repoEndpoint: 'http://localhost:8080',
+  repoEndpoint: 'http://patternpedia/localhost:8080',
   featureToggles: {
     designModel: false,
     patternCandidate: true,


### PR DESCRIPTION
…le under /patternpedia/