### PR TITLE
Fix markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # PatternAtlas
+
 ## License
 
 Copyright (c) 2019 University of Stuttgart.
@@ -13,37 +14,50 @@ and http://www.apache.org/licenses/LICENSE-2.0.
 [Eclipse Public License v1.0]: http://www.eclipse.org/legal/epl-v10.html
 
 ## Quantum Computing Pattern Support
+
 #### Latex Rendering
+
 PatternAtlas supports inline LaTeX code rendering for quantum computing patterns.
 This requires the setup of latex-renderer (https://github.com/UST-QuAntiL/latex-renderer).  
 PatternAtlas supports Qcircuit and Quantikz circuit defintions. 
-Simply copy your Qcircuit or Quantikz code into the content of a Pattern.  
-Qcircuit example:  
+Simply copy your Qcircuit or Quantikz code into the content of a Pattern.
+
+Qcircuit example:
+
+```latex
 \Qcircuit @C=1em @R=.7em {  
   & \ctrl{1} & \targ & \qw \\  
   & \targ & \ctrl{-1} & \qw  
-  end}    
-  ***Note:** the "end" tag is __required__ to close the Qcircuit section in PatternAtlas*    
+  end}
+```
+
+***Note:** the "end" tag is __required__ to close the Qcircuit section in PatternAtlas*    
+
 Quantikz example:  
- \begin{quantikz}
+
+```latex
+\begin{quantikz}
   & \targ{} & \gate{U} & \qw \\  
   & \ctrl{1} \vqw{-1} & \meter{} \vcw{-1} \\  
   & \targ{} & \qw  
-  \end{quantikz}  
+\end{quantikz}  
+```
 
 #### Discussion
+
 PatternAtlas supports the Discussion of the rendered Qcircuit and Quantikz circuits. 
 Simply click the "Comment Picture" button and mark an area within the circuit and then add your comment.
 To answer on comments click the marked area and submit your comment.     
 
 #### OpenQASM
+
 PatternAtlas supports the Integration of OpenQASM Algorithms. The algorithm will get displayed as a graphical circuit.
 Simply copy your OpenQASM code into the content of a Pattern. Make sure to add the __required__ "end" tag as shown in the example:  
+
+```OpenQASM
 OPENQASM 2.0;  
 include "qelib1.inc";  
 qreg q[2];  
 h q[0];  
 cx q[0], q[1]; end        
-
-
-
+```


### PR DESCRIPTION
I applied some [rules of markdown-lint](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#rules) to render the `README.md` more nicely:

Example:

![grafik](https://user-images.githubusercontent.com/1366654/120198835-dbf6e700-c222-11eb-8ea2-d3232b290a24.png)
