### PR TITLE
Fix disable editing buttons

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -69,15 +69,16 @@ export class AppComponent implements OnInit {
       (error: HttpErrorResponse) => {
         this.loading = false;
         if(error.status === globals.statusCodeNotFound){
-          this.configService.getDefaultConfiguration(); 
-          console.log('default values applied') 
+          this.configService.getDefaultConfiguration();
+          console.log('default values applied')
         }
-        else{
+        else if (this.configService.configuration.features[UiFeatures.SHOW_SETTINGS]){
           this.toasterService.popAsync(
             'error', 'Error while loading config from config server, using default values instead' + error.message).subscribe(
             () => console.log('default values applied')
           )
         }
+        console.log('Error while loading config from config server, using default values instead' + error.message)
       }
     );
   }

--- a/src/app/core/component/action-button-bar/action-button-bar.component.ts
+++ b/src/app/core/component/action-button-bar/action-button-bar.component.ts
@@ -1,7 +1,9 @@
 import {
   ApplicationRef, ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output
 } from '@angular/core';
-import { UiFeatures } from '../../directives/pattern-atlas-ui-repository-configuration.service';
+import {
+  PatternAtlasUiRepositoryConfigurationService, UiFeatures
+} from 'src/app/core/directives/pattern-atlas-ui-repository-configuration.service';
 
 @Component({
   selector: 'pp-action-button-bar',
@@ -28,11 +30,15 @@ export class ActionButtonBarComponent implements OnInit {
 
   @Input() displayText: string;
 
+  editingFromConfigServer = false;
+
   constructor(private cdr: ChangeDetectorRef,
-              private applicationRef: ApplicationRef) {
+              private applicationRef: ApplicationRef,
+              private configurationService: PatternAtlasUiRepositoryConfigurationService) {
   }
 
   ngOnInit() {
+    this.editingFromConfigServer = this.configurationService.configuration.features[UiFeatures.EDITING];
   }
 
   addButtonClicked() {
@@ -48,6 +54,8 @@ export class ActionButtonBarComponent implements OnInit {
   }
 
   iconEditButtonClicked() {
-    this.iconEditClicked.emit();
+    if (this.editingFromConfigServer) {
+      this.iconEditClicked.emit();
+    }
   }
 }

--- a/src/app/core/component/creative-license-footer/creative-license-footer.component.html
+++ b/src/app/core/component/creative-license-footer/creative-license-footer.component.html
@@ -1,8 +1,11 @@
 <footer *ngIf="patternLanguage?.creativeCommonsReference" class="center-content">
-  <p><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img
+  <div style="text-align:center;">
+    <p><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img
     alt="Creative Commons Lizenzvertrag"
     style="border-width:0"
     src="https://i.creativecommons.org/l/by/4.0/88x31.png"/></a>
+    <br>
     <a rel="license"
-       href="http://creativecommons.org/licenses/by/4.0/"> {{patternLanguage?.creativeCommonsReference}}</a></p>
+       href="{{patternLanguage?.creativeCommonsReference}}"> {{patternLanguage?.creativeCommonsReference}}</a></p></div>
+
 </footer>

--- a/src/app/core/component/markdown-content-container/markdown-pattern-sectioncontent/markdown-pattern-section-content.component.html
+++ b/src/app/core/component/markdown-content-container/markdown-pattern-sectioncontent/markdown-pattern-section-content.component.html
@@ -12,7 +12,7 @@
       <button *ngIf="showActionButtons && isEditingEnabled && editingFromConfigServer" mat-stroked-button
               style="margin-left: 5px" color="primary"
               (click)="openEditor()" matTooltip="Edit"><i class="material-icons">mode_edit</i></button>
-      <button *ngIf="showActionButtons && showCommentButton" mat-stroked-button
+      <button *ngIf="showActionButtons && showCommentButton && editingFromConfigServer" mat-stroked-button
               style="margin-left: 5px" color="primary"
               (click)="commentSVG()" matTooltip="Comment Picture"><i class="material-icons">comment</i></button>
     </div>

--- a/src/app/core/component/markdown-content-container/markdown-pattern-sectioncontent/markdown-pattern-section-content.component.html
+++ b/src/app/core/component/markdown-content-container/markdown-pattern-sectioncontent/markdown-pattern-section-content.component.html
@@ -9,7 +9,7 @@
       <div style="word-break: break-word" #markdownContent></div>
 
 
-      <button *ngIf="showActionButtons && isEditingEnabled" mat-stroked-button
+      <button *ngIf="showActionButtons && isEditingEnabled && editingFromConfigServer" mat-stroked-button
               style="margin-left: 5px" color="primary"
               (click)="openEditor()" matTooltip="Edit"><i class="material-icons">mode_edit</i></button>
       <button *ngIf="showActionButtons && showCommentButton" mat-stroked-button

--- a/src/app/core/component/markdown-content-container/markdown-pattern-sectioncontent/markdown-pattern-section-content.component.ts
+++ b/src/app/core/component/markdown-content-container/markdown-pattern-sectioncontent/markdown-pattern-section-content.component.ts
@@ -16,6 +16,9 @@ import { DiscussionService } from '../../../service/discussion.service';
 import { DiscussionComment } from '../../../model/discussion-comment';
 import { ImageModel } from '../../../model/image-model';
 import * as QuantumCircuit from 'quantum-circuit';
+import {
+  PatternAtlasUiRepositoryConfigurationService, UiFeatures
+} from 'src/app/core/directives/pattern-atlas-ui-repository-configuration.service';
 
 @Component({
   selector: 'pp-markdown-pattern-section-content',
@@ -36,10 +39,12 @@ export class MarkdownPatternSectionContentComponent extends DataRenderingCompone
   svgCommentHeight;
   comment;
   commentSvg: SVGSVGElement;
+  readonly UiFeatures = UiFeatures;
 
   isCommentingEnabled = false;
   showCommentButton = true;
   showActionButtons = false;
+  editingFromConfigServer = false
   @ViewChild('markdownContent') markdownDiv: ElementRef;
   @Input() content: string;
   private markdown: MarkdownIt;
@@ -48,10 +53,12 @@ export class MarkdownPatternSectionContentComponent extends DataRenderingCompone
               private cdr: ChangeDetectorRef,
               private imageService: ImageService,
               private snackBar: MatSnackBar,
-              private discussionService: DiscussionService
+              private discussionService: DiscussionService,
+              private configurationService: PatternAtlasUiRepositoryConfigurationService
   ) {
     super();
     this.changeContent = new EventEmitter<DataChange>();
+    this.editingFromConfigServer = this.configurationService.configuration.features[UiFeatures.EDITING]
   }
 
   ngAfterViewInit() {

--- a/src/app/core/default-pattern-renderer/default-pattern-renderer.component.html
+++ b/src/app/core/default-pattern-renderer/default-pattern-renderer.component.html
@@ -60,7 +60,7 @@
       <mat-card-actions>
         <div style="display: flex; align-items: center;">
           <button (click)="addLink()"
-                  *ngIf="isEditingEnabled"
+                  *ngIf="isEditingEnabled && editingFromConfigServer"
                   color="primary"
                   mat-stroked-button
                   matTooltip="Add Relation"

--- a/src/app/core/default-pattern-renderer/default-pattern-renderer.component.html
+++ b/src/app/core/default-pattern-renderer/default-pattern-renderer.component.html
@@ -5,7 +5,7 @@
                           [iconEdit]="true"
                           [iconUrl]="pattern?.iconUrl" (iconEditClicked)="editIcon()">
     </pp-action-button-bar>
-    <span> <button mat-stroked-button style="margin-left: 5px" color="primary" *ngIf="showActionButtons"
+    <span> <button mat-stroked-button style="margin-left: 5px" color="primary" *ngIf="showActionButtons && editingFromConfigServer"
                    (click)="editIcon()" matTooltip="Edit"><i class="material-icons">mode_edit</i></button>
   </span>
   </mat-card-header>

--- a/src/app/core/default-pattern-renderer/default-pattern-renderer.component.ts
+++ b/src/app/core/default-pattern-renderer/default-pattern-renderer.component.ts
@@ -24,6 +24,9 @@ import { UndirectedEdgeModel } from '../model/hal/undirected-edge.model';
 import { globals } from '../../globals';
 import { UriConverter } from '../util/uri-converter';
 import { EditUrlDialogComponent } from '../component/edit-url-dialog/edit-url-dialog.component';
+import {
+  PatternAtlasUiRepositoryConfigurationService, UiFeatures
+} from '../directives/pattern-atlas-ui-repository-configuration.service';
 
 @Component({
   selector: 'pp-default-pattern-renderer',
@@ -45,6 +48,8 @@ export class DefaultPatternRendererComponent implements AfterViewInit, OnDestroy
   private patternId: string;
   subscriptions: Subscription = new Subscription();
   showActionButtons: boolean;
+  readonly UiFeatures = UiFeatures;
+  editingFromConfigServer = false
 
   constructor(private activatedRoute: ActivatedRoute,
               private toasterService: ToasterService,
@@ -54,8 +59,10 @@ export class DefaultPatternRendererComponent implements AfterViewInit, OnDestroy
               private patternService: PatternService,
               private patternRelationDescriptorService: PatternRelationDescriptorService,
               private dialog: MatDialog,
-              private router: Router) {
+              private router: Router,
+              private configurationService: PatternAtlasUiRepositoryConfigurationService) {
     this.router.routeReuseStrategy.shouldReuseRoute = () => false;
+    this.editingFromConfigServer = this.configurationService.configuration.features[UiFeatures.EDITING]
   }
 
   ngAfterViewInit(): void {

--- a/src/app/core/directives/pattern-atlas-ui-repository-configuration.service.ts
+++ b/src/app/core/directives/pattern-atlas-ui-repository-configuration.service.ts
@@ -40,12 +40,12 @@ interface EtcdNode {
 
 const initialValues: PatternAtlasUiConfiguration = {
   features: {
-    designModel: true,
-    patternCandidate: true,
-    patternViews: true,
-    issue: true,
-    showSettings: true,
-    editing: true
+    designModel: false,
+    patternCandidate: false,
+    patternViews: false,
+    issue: false,
+    showSettings: false,
+    editing: false
   },
 };
 

--- a/src/app/pattern-language-management/pattern-language-management/pattern-language-management.component.scss
+++ b/src/app/pattern-language-management/pattern-language-management/pattern-language-management.component.scss
@@ -29,6 +29,7 @@
 
 .mat-card-image {
   cursor: pointer;
+  object-fit: contain;
 }
 
 .mat-card-avatar {


### PR DESCRIPTION
This PR removes the buttons to edit the markdown of patterns if editing is switched off in the configuration.