### PR TITLE
Movable graph nodes in read-only mode

### DIFF
--- a/src/app/core/component/graph-display/graph-display.component.html
+++ b/src/app/core/component/graph-display/graph-display.component.html
@@ -116,7 +116,7 @@
                    (onNodePositionChange)="handleNodePositionChangedEvent($event)"
                    [ppGraphEventEmmiter]
                    classes=" highlighted-edge low-opacity-node low-opacity-edge"
-                   [mode]="configuration.features.editing ? 'layout' : 'display'"
+                   mode="layout"
                    style="width: 100%; height: 100%"
                    zoom="both">
       <svg #svg slot="graph" [class.left-sidenav-open]="!!patternContainer">


### PR DESCRIPTION
This PR allows that nodes of a pattern language's graph can be moved in read-only mode.
However, due to the read-only mode, the repositioning of the nodes is not stored.

Signed-off-by: Marvin Bechtold <marvin.bechtold.dev@gmail.com>