### PR TITLE
Add deployment modeling flags

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -46,7 +46,7 @@
       Pattern Languages
     </a>
     <a mat-tab-link [routerLink]="'/' + pathConstants.patternViews"
-       *patternAtlasUiShowOnFeature="UiFeatures.PATTERNVIEWS"
+       *patternAtlasUiShowOnFeature="UiFeatures.PATTERN_VIEWS"
        routerLinkActive="" #rla2="routerLinkActive" [active]="rla2.isActive">
       Pattern Views
     </a>
@@ -55,7 +55,7 @@
        routerLinkActive="" #rla3="routerLinkActive" [active]="rla3.isActive">
       Design Models
     </a>
-    <a mat-tab-link [routerLink]="'/candidate'" *patternAtlasUiShowOnFeature="UiFeatures.PATTERNCANDIDATE"
+    <a mat-tab-link [routerLink]="'/candidate'" *patternAtlasUiShowOnFeature="UiFeatures.PATTERN_CANDIDATE"
        routerLinkActive="" #rla4="routerLinkActive" [active]="rla4.isActive">
       Pattern Candidate
     </a>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -32,35 +32,35 @@
             <button *ngIf="!planqkUi" mat-menu-item routerLink="/user-info"> UserInfo </button>
             <button *ngIf="p.userHasPrivilege('USER_READ_ALL') | async" mat-menu-item routerLink="/admin"> Admin </button>
             <!-- <button mat-menu-item routerLink="/developer"> Developer </button> -->
-            <button *ngIf="!planqkUi" mat-menu-item (click)="openFeatureToggleDialog()">
+            <button *ngIf="showFeatureFlag" mat-menu-item (click)="openFeatureToggleDialog()">
               <span>Feature Toggles</span>
             </button>
-            <button mat-menu-item color="warn" (click)="logout()"> Logout </button>
+            <button mat-menu-item (click)="logout()"> Logout </button>
         </mat-menu>
     </div>
   </mat-toolbar>
 
   <nav mat-tab-nav-bar>
     <a mat-tab-link [routerLink]="'/' + pathConstants.patternLanguages"
-       routerLinkActive #rla1="routerLinkActive" [active]="rla1.isActive">
+       routerLinkActive="" #rla1="routerLinkActive" [active]="rla1.isActive">
       Pattern Languages
     </a>
     <a mat-tab-link [routerLink]="'/' + pathConstants.patternViews"
        *patternAtlasUiShowOnFeature="UiFeatures.PATTERNVIEWS"
-       routerLinkActive #rla2="routerLinkActive" [active]="rla2.isActive">
+       routerLinkActive="" #rla2="routerLinkActive" [active]="rla2.isActive">
       Pattern Views
     </a>
     <a mat-tab-link [routerLink]="'/' + pathConstants.designModels"
        *patternAtlasUiShowOnFeature="UiFeatures.DESIGN_MODEL"
-       routerLinkActive #rla3="routerLinkActive" [active]="rla3.isActive">
+       routerLinkActive="" #rla3="routerLinkActive" [active]="rla3.isActive">
       Design Models
     </a>
     <a mat-tab-link [routerLink]="'/candidate'" *patternAtlasUiShowOnFeature="UiFeatures.PATTERNCANDIDATE"
-       routerLinkActive #rla4="routerLinkActive" [active]="rla4.isActive">
+       routerLinkActive="" #rla4="routerLinkActive" [active]="rla4.isActive">
       Pattern Candidate
     </a>
     <a mat-tab-link [routerLink]="'/issue'" *patternAtlasUiShowOnFeature="UiFeatures.ISSUE"
-       routerLinkActive #rla5="routerLinkActive" [active]="rla5.isActive">
+       routerLinkActive="" #rla5="routerLinkActive" [active]="rla5.isActive">
       Issue
     </a>
   </nav>

--- a/src/app/core/component/edit-url-dialog/edit-url-dialog.component.html
+++ b/src/app/core/component/edit-url-dialog/edit-url-dialog.component.html
@@ -2,19 +2,29 @@
 <div mat-dialog-content>
   <mat-form-field>
     <mat-label>Adjust Pattern Name</mat-label>
-    <input matInput placeholder={{data.pattern.name}} [(ngModel)]="data.name">
+    <input matInput placeholder={{data.pattern.name}} [(ngModel)]="data.pattern.name">
   </mat-form-field>
   <mat-form-field>
     <mat-label>Adjust Icon URL</mat-label>
-    <input matInput placeholder={{data.pattern.iconUrl}} [(ngModel)]="data.icon">
+    <input matInput placeholder={{data.pattern.iconUrl}} [(ngModel)]="data.pattern.iconUrl">
   </mat-form-field>
   <mat-form-field>
     <mat-label>Adjust Paper Reference</mat-label>
-    <input matInput placeholder={{data.pattern.patternRef}} [(ngModel)]="data.paperRef">
+    <input matInput placeholder={{data.pattern.patternRef}} [(ngModel)]="data.pattern.paperRef">
   </mat-form-field>
 
+  <div *patternAtlasUiShowOnFeature="UiFeatures.DEPLOYMENT_MODELLING">
+    <mat-checkbox [(ngModel)]="data.pattern.deploymentModelingBehaviorPattern">
+      Behavior Pattern
+    </mat-checkbox>
+    <br>
+    <mat-checkbox [(ngModel)]="data.pattern.deploymentModelingStructurePattern">
+      Component Pattern
+    </mat-checkbox>
+  </div>
+
 </div>
-<mat-dialog-actions align="end">
+<mat-dialog-actions>
   <button mat-button (click)="onNoClick()">Cancel</button>
-  <button mat-button [mat-dialog-close]="data" cdkFocusInitial>Ok</button>
+  <button mat-button [mat-dialog-close]="data">Ok</button>
 </mat-dialog-actions>

--- a/src/app/core/component/edit-url-dialog/edit-url-dialog.component.html
+++ b/src/app/core/component/edit-url-dialog/edit-url-dialog.component.html
@@ -10,7 +10,7 @@
   </mat-form-field>
   <mat-form-field>
     <mat-label>Adjust Paper Reference</mat-label>
-    <input matInput placeholder={{data.pattern.patternRef}} [(ngModel)]="data.pattern.paperRef">
+    <input matInput placeholder={{data.pattern.paperRef}} [(ngModel)]="data.pattern.paperRef">
   </mat-form-field>
 
   <div *patternAtlasUiShowOnFeature="UiFeatures.DEPLOYMENT_MODELLING">

--- a/src/app/core/component/edit-url-dialog/edit-url-dialog.component.ts
+++ b/src/app/core/component/edit-url-dialog/edit-url-dialog.component.ts
@@ -1,5 +1,7 @@
 import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { UiFeatures } from '../../directives/pattern-atlas-ui-repository-configuration.service';
+import Pattern from '../../model/hal/pattern.model';
 
 @Component({
   selector: 'pp-edit-url-dialog',
@@ -8,9 +10,13 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 })
 export class EditUrlDialogComponent {
 
+  readonly UiFeatures = UiFeatures;
+
   constructor(
     public dialogRef: MatDialogRef<EditUrlDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data) {
+    @Inject(MAT_DIALOG_DATA) public data: {
+      pattern: Pattern
+    }) {
   }
 
   onNoClick(): void {

--- a/src/app/core/component/feature-toggle-dialog/feature-toggle-dialog.component.html
+++ b/src/app/core/component/feature-toggle-dialog/feature-toggle-dialog.component.html
@@ -16,13 +16,13 @@
          name="patternCandidate"
          [checked]="config.features.patternCandidate"
          [disabled]="disabled()"
-         (change)="toggleFeature(UiFeatures.PATTERNCANDIDATE, $event)">
+         (change)="toggleFeature(UiFeatures.PATTERN_CANDIDATE, $event)">
   <label for="patternCandidate">Pattern Candidate</label>
   <br>
   <input type="checkbox" [(ngModel)]="config.features.patternViews" id="patternViews" name="patternViews"
          [checked]="config.features.patternViews"
          [disabled]="disabled()"
-         (change)="toggleFeature(UiFeatures.PATTERNVIEWS, $event)">
+         (change)="toggleFeature(UiFeatures.PATTERN_VIEWS, $event)">
   <label for="patternViews">Pattern Views</label>
   <br>
   <input type="checkbox" [(ngModel)]="config.features.editing" id="editing" name="editing"

--- a/src/app/core/component/feature-toggle-dialog/feature-toggle-dialog.component.html
+++ b/src/app/core/component/feature-toggle-dialog/feature-toggle-dialog.component.html
@@ -2,34 +2,40 @@
 <div mat-card-content>
   <input type="checkbox" [(ngModel)]="config.features.designModel" id="designModel" name="designModel"
          [checked]="config.features.designModel" (change)="toggleFeature(UiFeatures.DESIGN_MODEL, $event)"
-         [disabled]="!config.features.showSettings">
+         [disabled]="disabled()">
   <label for="designModel">Design Model</label>
   <br>
   <input type="checkbox" [(ngModel)]="config.features.issue"
          id="issue" name="issue"
          [checked]="config.features.issue"
-         [disabled]="!config.features.showSettings"
+         [disabled]="disabled()"
          (change)="toggleFeature(UiFeatures.ISSUE, $event)">
   <label for="issue">Issue</label>
   <br>
   <input type="checkbox" [(ngModel)]="config.features.patternCandidate" id="patternCandidate"
          name="patternCandidate"
          [checked]="config.features.patternCandidate"
-         [disabled]="!config.features.showSettings"
+         [disabled]="disabled()"
          (change)="toggleFeature(UiFeatures.PATTERNCANDIDATE, $event)">
   <label for="patternCandidate">Pattern Candidate</label>
   <br>
   <input type="checkbox" [(ngModel)]="config.features.patternViews" id="patternViews" name="patternViews"
          [checked]="config.features.patternViews"
-         [disabled]="!config.features.showSettings"
+         [disabled]="disabled()"
          (change)="toggleFeature(UiFeatures.PATTERNVIEWS, $event)">
   <label for="patternViews">Pattern Views</label>
   <br>
   <input type="checkbox" [(ngModel)]="config.features.editing" id="editing" name="editing"
          [checked]="config.features.editing"
-         [disabled]="!config.features.showSettings"
+         [disabled]="disabled()"
          (change)="toggleFeature(UiFeatures.EDITING, $event)">
-  <label for="patternViews">Editing</label>
+  <label for="editing">Editing</label>
+  <br>
+  <input type="checkbox" [(ngModel)]="config.features.deploymentModelling" id="deploymentModeling" name="deploymentModeling"
+         [checked]="config.features.deploymentModelling"
+         [disabled]="disabled()"
+         (change)="toggleFeature(UiFeatures.DEPLOYMENT_MODELLING, $event)">
+  <label for="deploymentModeling">Show Deployment Modeling settings</label>
 </div>
 <div mat-dialog-actions>
   <button mat-button (click)="onCloseDialogClick()">Close</button>

--- a/src/app/core/component/feature-toggle-dialog/feature-toggle-dialog.component.ts
+++ b/src/app/core/component/feature-toggle-dialog/feature-toggle-dialog.component.ts
@@ -33,7 +33,7 @@ export class FeatureToggleDialogComponent implements OnInit {
   }
 
   toggleFeature(feature: UiFeatures, event: Event): void {
-    if (this.config.features.showSettings) {
+    if (this.config.features.showSettings || this.data.isAdmin) {
       this.configService.applyConfig(feature, event.target['checked']).subscribe(
         () => this.toasterService.pop('success', 'Successfully updated the config!'),
         () =>

--- a/src/app/core/component/feature-toggle-dialog/feature-toggle-dialog.component.ts
+++ b/src/app/core/component/feature-toggle-dialog/feature-toggle-dialog.component.ts
@@ -1,10 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import {
   PatternAtlasUiConfiguration, PatternAtlasUiRepositoryConfigurationService, UiFeatures
 } from '../../directives/pattern-atlas-ui-repository-configuration.service';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { ToasterService } from 'angular2-toaster';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 
 @Component({
   selector: 'pp-feature-toggle-dialog',
@@ -19,8 +19,13 @@ export class FeatureToggleDialogComponent implements OnInit {
   constructor(
     private http: HttpClient, private toasterService: ToasterService,
     private configService: PatternAtlasUiRepositoryConfigurationService,
-    public dialogRef: MatDialogRef<FeatureToggleDialogComponent>
+    public dialogRef: MatDialogRef<FeatureToggleDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { isAdmin: boolean }
   ) {
+  }
+
+  public disabled(): boolean {
+    return !(this.config.features.showSettings || this.data.isAdmin);
   }
 
   ngOnInit(): void {
@@ -31,7 +36,7 @@ export class FeatureToggleDialogComponent implements OnInit {
     if (this.config.features.showSettings) {
       this.configService.applyConfig(feature, event.target['checked']).subscribe(
         () => this.toasterService.pop('success', 'Successfully updated the config!'),
-        (error: HttpErrorResponse) =>
+        () =>
           this.toasterService.pop(
             'error', 'Error while saving config!'
           )

--- a/src/app/core/default-pattern-renderer/default-pattern-renderer.component.html
+++ b/src/app/core/default-pattern-renderer/default-pattern-renderer.component.html
@@ -5,8 +5,8 @@
                           [iconEdit]="true"
                           [iconUrl]="pattern?.iconUrl" (iconEditClicked)="editIcon()">
     </pp-action-button-bar>
-      <button mat-stroked-button style="margin-left: 5px" color="primary" *ngIf="showActionButtons && isEditingEnabled"
-                     (click)="editIcon()" matTooltip="Edit"><i class="material-icons">mode_edit</i></button>
+    <button mat-stroked-button style="margin-left: 5px" color="primary" *ngIf="showActionButtons && isEditingEnabled"
+            (click)="editIcon()" matTooltip="Edit"><i class="material-icons">mode_edit</i></button>
   </mat-card-header>
 
   <span class="copyright" *ngIf="pattern?.paperRef"> <i class="material-icons">copyright</i>
@@ -19,61 +19,79 @@
   <div>
     <ng-template ppPatternProperty></ng-template>
   </div>
-  <mat-card *ngIf="!isLoading" class="section-card">
-    <mat-card-header>
-      <mat-card-subtitle style="display: flex;
-     align-items: flex-start;"><b>Relations to other Patterns</b></mat-card-subtitle>
-    </mat-card-header>
-    <mat-card-content>
-      <div *ngIf="directedPatternRelations?.length > 0">
-        <ng-container *ngFor="let relation of directedPatternRelations">
-          <p class="horiz-centered">
-            <a [routerLink]="['..',relation.sourcePatternId]">{{ relation?.sourcePatternName}}</a>
-            <span *ngIf="relation?.type" class="horiz-centered">
+
+  <ng-container *ngIf="!isLoading">
+    <mat-card class="section-card">
+      <mat-card-header>
+        <mat-card-subtitle class="subtitle"><b>Relations to other Patterns</b></mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <div *ngIf="directedPatternRelations?.length > 0">
+          <ng-container *ngFor="let relation of directedPatternRelations">
+            <p class="horiz-centered">
+              <a [routerLink]="['..',relation.sourcePatternId]">{{ relation?.sourcePatternName}}</a>
+              <span *ngIf="relation?.type" class="horiz-centered">
                             <i class="material-icons">remove</i>{{relation?.type}}
                         </span>
-            <i class="material-icons">trending_flat</i>
-            <a [routerLink]="['..', relation.targetPatternId]">{{ relation?.targetPatternName}}</a>
-            <i>{{relation?.description ? ': ' + relation?.description : ''}}</i>
-          </p>
-          <br/>
-        </ng-container>
-      </div>
-      <div *ngIf="undirectedPatternRelations?.length > 0">
-        <ng-container *ngFor="let relation of undirectedPatternRelations">
-          <p class="horiz-centered">
-            <a [routerLink]="['..', relation.pattern1Uri]">{{ relation?.pattern1Name}}</a>
-            <span *ngIf="!relation?.type"><i class="material-icons">compare_arrows</i></span>
-            <span *ngIf="relation?.type" class="horiz-centered"><i
-              class="material-icons flip">trending_flat</i>{{relation?.type}}
-              <i class="material-icons">trending_flat</i></span>
-            <a [routerLink]="['..',relation.pattern2Uri]">{{ relation?.pattern2Name}}</a>
-            <i>{{relation?.description ? ': ' + relation?.description : ''}}</i>
-          </p>
-          <br/>
-        </ng-container>
-      </div>
-      <div *ngIf="undirectedPatternRelations?.length === 0 && directedPatternRelations?.length === 0">
-        <p> No links found for this pattern.</p>
-      </div>
-      <mat-card-actions>
-        <div style="display: flex; align-items: center;">
-          <button (click)="addLink()"
-                  *ngIf="isEditingEnabled"
-                  color="primary"
-                  mat-stroked-button
-                  matTooltip="Add Relation"
-                  style="margin-left: 5px">
-            <i class="material-icons">trending_flat</i>
-            <i class="material-icons" style="height: 2em;
-    font-size: smaller;  ">add</i>
-          </button>
+              <i class="material-icons">trending_flat</i>
+              <a [routerLink]="['..', relation.targetPatternId]">{{ relation?.targetPatternName}}</a>
+              <i>{{relation?.description ? ': ' + relation?.description : ''}}</i>
+            </p>
+            <br/>
+          </ng-container>
         </div>
-      </mat-card-actions>
-    </mat-card-content>
+        <div *ngIf="undirectedPatternRelations?.length > 0">
+          <ng-container *ngFor="let relation of undirectedPatternRelations">
+            <p class="horiz-centered">
+              <a [routerLink]="['..', relation.pattern1Uri]">{{ relation?.pattern1Name}}</a>
+              <span *ngIf="!relation?.type"><i class="material-icons">compare_arrows</i></span>
+              <span *ngIf="relation?.type" class="horiz-centered"><i
+                class="material-icons flip">trending_flat</i>{{relation?.type}}
+                <i class="material-icons">trending_flat</i></span>
+              <a [routerLink]="['..',relation.pattern2Uri]">{{ relation?.pattern2Name}}</a>
+              <i>{{relation?.description ? ': ' + relation?.description : ''}}</i>
+            </p>
+            <br/>
+          </ng-container>
+        </div>
+        <div *ngIf="undirectedPatternRelations?.length === 0 && directedPatternRelations?.length === 0">
+          <p> No links found for this pattern.</p>
+        </div>
+        <mat-card-actions>
+          <div style="display: flex; align-items: center;">
+            <button (click)="addLink()"
+                    *ngIf="isEditingEnabled"
+                    color="primary"
+                    mat-stroked-button
+                    matTooltip="Add Relation"
+                    style="margin-left: 5px">
+              <i class="material-icons">trending_flat</i>
+              <i class="material-icons" style="height: 2em;
+    font-size: smaller;  ">add</i>
+            </button>
+          </div>
+        </mat-card-actions>
+      </mat-card-content>
+    </mat-card>
 
-  </mat-card>
-
+    <mat-card class="section-card" *patternAtlasUiShowOnFeature="UiFeatures.DEPLOYMENT_MODELLING">
+      <mat-card-header>
+        <mat-card-subtitle class="'subtitle'"><b>Usage in Deployment Modelling</b></mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <p>
+          <input type="checkbox" disabled id="structurePattern" [checked]="pattern?.deploymentModelingStructurePattern">
+          <label for="structurePattern">Pattern can be used as a <b>Component Pattern</b> to represent a structural element
+            in a deployment model</label>
+        </p>
+        <p>
+          <input type="checkbox" disabled id="behaviorPattern" [checked]="pattern?.deploymentModelingBehaviorPattern">
+          <label for="behaviorPattern">Pattern can be used as a <b>Behavior Pattern</b> to describe an element's behavior in
+            a deployment model</label>
+        </p>
+      </mat-card-content>
+    </mat-card>
+  </ng-container>
 </mat-card>
 <pp-creative-license-footer *ngIf="pattern && patternLanguage"
                             [patternLanguage]="patternLanguage"></pp-creative-license-footer>

--- a/src/app/core/default-pattern-renderer/default-pattern-renderer.component.scss
+++ b/src/app/core/default-pattern-renderer/default-pattern-renderer.component.scss
@@ -23,3 +23,8 @@
   display: flex;
   align-items: center;
 }
+
+.subtitle {
+  display: flex;
+  align-items: flex-start;
+}

--- a/src/app/core/default-pattern-renderer/default-pattern-renderer.component.ts
+++ b/src/app/core/default-pattern-renderer/default-pattern-renderer.component.ts
@@ -42,8 +42,8 @@ export class DefaultPatternRendererComponent implements AfterViewInit, OnDestroy
   patternLanguage: PatternLanguage;
   pattern: Pattern;
   patterns: Array<Pattern>;
-  private directedPatternRelations: Array<DirectedEdgeModel>;
-  private undirectedPatternRelations: Array<UndirectedEdgeModel>;
+  directedPatternRelations: Array<DirectedEdgeModel>;
+  undirectedPatternRelations: Array<UndirectedEdgeModel>;
   private viewContainerRef;
   private patternLanguageId: string;
   private patternId: string;
@@ -100,7 +100,7 @@ export class DefaultPatternRendererComponent implements AfterViewInit, OnDestroy
       console.log('tried to get patterns before the pattern language object with the url was instanciated');
       return EMPTY;
     }
-    // check if pattern is specified via UUIID or URI and load it accordingly
+    // check if pattern is specified via UUID or URI and load it accordingly
     if (UriConverter.isUUID(this.patternId)) {
       return this.patternService.getPatternById(this.patternLanguage, this.patternId).pipe(
         tap(pattern => this.pattern = pattern),
@@ -216,7 +216,7 @@ export class DefaultPatternRendererComponent implements AfterViewInit, OnDestroy
       tap((patternLanguage) => this.patternLanguage = patternLanguage),
       // load the rest: get our individual pattern and the links in parallel
       switchMap(() => forkJoin([this.getPatternObservable(), this.fillPatternSectionData(), this.getPatternLanguageLinks()])))
-      .subscribe(res => this.cdr.detectChanges());
+      .subscribe(() => this.cdr.detectChanges());
     this.subscriptions.add(subscription);
 
   }
@@ -240,7 +240,7 @@ export class DefaultPatternRendererComponent implements AfterViewInit, OnDestroy
         return edge ? this.insertEdge(edge) : EMPTY;
       }))
       .subscribe(
-        data => {
+        () => {
           this.toasterService.pop('success', 'Created new Relation');
         }
       );
@@ -266,9 +266,6 @@ export class DefaultPatternRendererComponent implements AfterViewInit, OnDestroy
     });
     dialogRef.afterClosed().subscribe(result => {
       if (result !== undefined) {
-        this.pattern.iconUrl = result.icon;
-        this.pattern.name = result.name;
-        this.pattern.paperRef = result.paperRef;
         this.patternService.updatePattern(this.pattern._links.self.href, this.pattern).subscribe();
       }
     });

--- a/src/app/core/default-pl-renderer/default-pl-renderer.component.html
+++ b/src/app/core/default-pl-renderer/default-pl-renderer.component.html
@@ -20,12 +20,12 @@
 
 <mat-progress-spinner *ngIf="isLoadingPatternData" mode="indeterminate"></mat-progress-spinner>
 <div>
-  <div *patternAtlasUiHideOnFeature="UiFeatures.PATTERNCANDIDATE">
+  <div *patternAtlasUiHideOnFeature="UiFeatures.PATTERN_CANDIDATE">
     <pp-card-renderer *ngIf="!graphVisible && patterns && patternsForCardsView"
                         [uriEntities]="this.patternsForCardsView"
                         [showLinks]="false"></pp-card-renderer>
   </div>
-  <div *patternAtlasUiShowOnFeature="UiFeatures.PATTERNCANDIDATE">
+  <div *patternAtlasUiShowOnFeature="UiFeatures.PATTERN_CANDIDATE">
     <mat-tab-group *ngIf="!graphVisible" mat-align-tabs="start">
       <mat-tab label="Patterns">
         <pp-card-renderer *ngIf="patterns && patternsForCardsView"
@@ -39,8 +39,8 @@
   </div>
   <!-- setup graph child including emit methods -->
   <pp-graph-display *ngIf="graphVisible && patterns && !isLoadingLinkData" [data]="{
-                patterns: this.patterns, edges: this.patternLinks,
-                patternLanguage: this.patternLanguage, patternContainer: null
+                patterns: this.patterns, edges: this.patternLinks, copyOfLinks: [],
+                patternLanguage: this.patternLanguage, patternContainer: null, patternLanguages: []
             }" (addedEdge)="handleLinkAddedInGraphEditor($event)" (removedEdge)="handleLinkRemovedInGraphEditor($event)"
                     [showPatternLanguageName]="false">
   </pp-graph-display>

--- a/src/app/core/default-pl-renderer/default-pl-renderer.component.ts
+++ b/src/app/core/default-pl-renderer/default-pl-renderer.component.ts
@@ -20,8 +20,8 @@ import { PatternRelationDescriptorService } from '../service/pattern-relation-de
 import { ToasterService } from 'angular2-toaster';
 import { PatternService } from '../service/pattern.service';
 import Pattern from '../model/hal/pattern.model';
-import { CandidateManagementService } from '../candidate-management/_services/candidate-management.service';
-import { Candidate } from '../candidate-management/_models/candidate.model';
+import { CandidateManagementService } from '../candidate-management';
+import { Candidate } from '../candidate-management';
 import { FormControl } from '@angular/forms';
 import { globals } from '../../globals';
 import { PatternRelationDescriptorDirection } from '../model/pattern-relation-descriptor-direction.enum';
@@ -51,7 +51,7 @@ export class DefaultPlRendererComponent implements OnInit, OnDestroy {
   filter: FormControl;
   private directedPatternRelations: Array<DirectedEdgeModel> = [];
   private undirectedPatternRelations: Array<UndirectedEdgeModel> = [];
-  private patternLinks: Array<UndirectedEdgeModel | DirectedEdgeModel>;
+  patternLinks: Array<UndirectedEdgeModel | DirectedEdgeModel>;
   subscriptions = new Subscription();
 
   constructor(private activatedRoute: ActivatedRoute,
@@ -87,7 +87,7 @@ export class DefaultPlRendererComponent implements OnInit, OnDestroy {
     const $getDirectedEdges = this.getDirectedEdges();
     const $getUndirectedEdges = this.getUndirectedEdges();
     return forkJoin([$getDirectedEdges, $getUndirectedEdges]).pipe(
-      tap((edges) => {
+      tap(() => {
         this.patternLinks = [];
         this.patternLinks.push(...this.directedPatternRelations);
         this.patternLinks.push(...this.undirectedPatternRelations);

--- a/src/app/core/directives/pattern-atlas-ui-repository-configuration.service.ts
+++ b/src/app/core/directives/pattern-atlas-ui-repository-configuration.service.ts
@@ -6,8 +6,8 @@ import { map } from 'rxjs/operators';
 
 export enum UiFeatures {
   DESIGN_MODEL = 'designModel',
-  PATTERNCANDIDATE = 'patternCandidate',
-  PATTERNVIEWS = 'patternViews',
+  PATTERN_CANDIDATE = 'patternCandidate',
+  PATTERN_VIEWS = 'patternViews',
   ISSUE = 'issue',
   SHOW_SETTINGS = 'showSettings',
   EDITING = 'editing',

--- a/src/app/core/directives/pattern-atlas-ui-repository-configuration.service.ts
+++ b/src/app/core/directives/pattern-atlas-ui-repository-configuration.service.ts
@@ -12,7 +12,8 @@ export enum UiFeatures {
   SHOW_SETTINGS = 'showSettings',
   EDITING = 'editing',
   AUTHENTICATION = 'authentication',
-  PLANQK_UI = 'planqkUi'
+  PLANQK_UI = 'planqkUi',
+  DEPLOYMENT_MODELLING = 'deploymentModelling'
 }
 
 export interface PatternAtlasUiConfiguration {
@@ -24,7 +25,8 @@ export interface PatternAtlasUiConfiguration {
     showSettings: boolean,
     editing: boolean,
     authentication: boolean,
-    planqkUi: boolean
+    planqkUi: boolean,
+    deploymentModelling: boolean,
   };
 }
 
@@ -51,7 +53,8 @@ const initialValues: PatternAtlasUiConfiguration = {
     showSettings: true,
     editing: true,
     authentication: true,
-    planqkUi: false
+    planqkUi: false,
+    deploymentModelling: false,
   },
 };
 
@@ -93,6 +96,8 @@ export class PatternAtlasUiRepositoryConfigurationService {
   }
 
   applyConfig(feature: UiFeatures, checked: boolean): Observable<string> {
+    this._configuration.features[feature] = checked;
+
     const url = environment.CONFIG_SERVER_URL + '/features/' + feature;
 
     return this.http.put<string>(

--- a/src/app/core/model/hal/pattern.model.ts
+++ b/src/app/core/model/hal/pattern.model.ts
@@ -22,6 +22,11 @@ class Pattern extends UriEntity {
   renderedContent: any;
   patternLanguageId: string;
   patternLanguageName: string;
+
+  // extension for deployment modelling
+  deploymentModelingBehaviorPattern: boolean;
+  deploymentModelingStructurePattern: boolean;
+
   _links: {
     self: HalLink;
     content: HalLink;

--- a/src/app/pattern-view-management/add-to-view/add-to-view.component.ts
+++ b/src/app/pattern-view-management/add-to-view/add-to-view.component.ts
@@ -242,7 +242,7 @@ export class AddToViewComponent {
 
   private getPatternsAndAddToTree(item: PatternLanguage, treenode, node) {
     this.patternService.getPatternsByUrl(item._links.patterns.href).subscribe((patterns) => {
-      const dummy = {
+      const dummy : Pattern = {
         id: this.LOAD_MORE,
         name: '',
         uri: '',
@@ -250,7 +250,9 @@ export class AddToViewComponent {
         renderedContent: null,
         _links: null,
         patternLanguageId: '',
-        patternLanguageName: ''
+        patternLanguageName: '',
+        deploymentModelingBehaviorPattern: false,
+        deploymentModelingStructurePattern: false
       };
       const childnodes = patterns.length > 0 ? patterns.map(it => new LoadmoreNode(it)) : [new LoadmoreNode(dummy)];
 

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -11,5 +11,5 @@
   window['env']['LATEX_RENDERER_PORT'] = 5030;
   window['env']['PATTERN_ATLAS_API_PORT'] = 1977;
   window['env']['URL_SCHEME'] = 'http';
-  window['env']['AUTH_REALM_URL'] = 'http://localhost:8080/realms/patternatlas';
+  window['env']['AUTH_REALM_URL'] = 'http://localhost:7080/realms/patternatlas';
 })(this);


### PR DESCRIPTION
This adds support for specifying whether a pattern can be used as Component Pattern or Behavior Pattern to integrate it with [Winery](https://github.com/eclipse/winery).

Depends on https://github.com/PatternAtlas/pattern-atlas-api/pull/58.

Example:
![image](https://user-images.githubusercontent.com/23058331/211531528-d5dd046f-fb76-42ed-b28b-b8a259ef8f66.png)
