### PR TITLE
Fix lines not attaching with a square angle

### DIFF
--- a/src/app/core/component/graph-display/graph-display.component.html
+++ b/src/app/core/component/graph-display/graph-display.component.html
@@ -197,19 +197,19 @@
             <rect data-click="nodeclick" data-link-handles="edges" height="50" rx="5" ry="5"
                   style="stroke:black;stroke-width:1;"
                   width="170"
-                  x="-60" y="-25">
+                  x="-85" y="-25">
             </rect>
             <!-- set both height and width values to define a maximum value for them -->
-            <image height="35" width="35" x="-55" y="-17.5" data-click="iconUrl" data-href="iconUrl"></image>
+            <image height="35" width="35" x="-80" y="-17.5" data-click="iconUrl" data-href="iconUrl"></image>
             <image *ngIf="enableDeletePattern" data-click="delete" data-content="patternLanguageId" class="node-action"
-                   width="10" x="80" y="-20" xlink:href="assets/delete.svg"/>
-            <image data-click="info" data-content="patternLanguageId" width="10" x="95"
+                   width="10" x="55" y="-20" xlink:href="assets/delete.svg"/>
+            <image data-click="info" data-content="patternLanguageId" width="10" x="70"
                    xlink:href="assets/Info_Simple_bw.svg" class="node-action"
                    y="-20"/>
             <text class="text" data-click="title" data-content="title" dominant-baseline="middle"
                   height="50" text-anchor="middle" style="font-weight: bold"
                   width="120"
-                  x="45"
+                  x="20"
                   y="0">
             </text>
             <text class="text cursive" data-click="patternLanguageName" *ngIf="showPatternLanguageName"
@@ -217,10 +217,10 @@
                   dominant-baseline="middle"
                   height="50" text-anchor="middle"
                   width="120"
-                  x="45"
+                  x="20"
                   y="10">
             </text>
-            <g class="concrete-solutions-container" transform="translate(-60,25)"></g>
+            <g class="concrete-solutions-container" transform="translate(-85,25)"></g>
           </g>
 
           <g data-line-attachement-point="-9 0" data-template-type="marker"


### PR DESCRIPTION
Center node graphics around 0,0 (move everything 25 units left)

This works because the line attachement angles are calculated as the angle between 0,0 and the attachement point (all coordinates relative to the node group).