### PR TITLE
Change default config for non testing/localhost deployment

### DIFF
--- a/src/app/core/directives/pattern-atlas-ui-repository-configuration.service.ts
+++ b/src/app/core/directives/pattern-atlas-ui-repository-configuration.service.ts
@@ -70,7 +70,6 @@ export class PatternAtlasUiRepositoryConfigurationService {
   }
 
   get configuration(): PatternAtlasUiConfiguration {
-    console.log(this._configuration)
     return this._configuration;
   }
 

--- a/src/app/core/directives/pattern-atlas-ui-repository-configuration.service.ts
+++ b/src/app/core/directives/pattern-atlas-ui-repository-configuration.service.ts
@@ -44,16 +44,18 @@ interface EtcdNode {
   createdIndex: number;
 }
 
+const IS_LOCALHOST = window.location?.hostname === 'localhost';
+
 const initialValues: PatternAtlasUiConfiguration = {
   features: {
     designModel: false,
-    patternCandidate: true,
+    patternCandidate: IS_LOCALHOST ? true : false,
     patternViews: false,
-    issue: true,
-    showSettings: true,
-    editing: true,
-    authentication: true,
-    planqkUi: false,
+    issue: IS_LOCALHOST ? true : false,
+    showSettings: IS_LOCALHOST ? true : false,
+    editing: IS_LOCALHOST ? true : false,
+    authentication: IS_LOCALHOST ? true : false,
+    planqkUi: IS_LOCALHOST ? false : true,
     deploymentModelling: false,
   },
 };
@@ -68,6 +70,7 @@ export class PatternAtlasUiRepositoryConfigurationService {
   }
 
   get configuration(): PatternAtlasUiConfiguration {
+    console.log(this._configuration)
     return this._configuration;
   }
 


### PR DESCRIPTION
Disable most features (login, editing, etc.) and assume deployment in PlanQK mode by default when not running under localhost.